### PR TITLE
Implement password inputbox and partial createSite button

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,16 +1,19 @@
 {
-  "root": true,
   "env": {
-    "browser": true,
-    "es2021": true
+      "browser": true,
+      "es2021": true
   },
-  "extends": ["airbnb-base"],
+  "extends": [
+      "airbnb-base"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": 12,
-    "sourceType": "module"
+      "ecmaVersion": 12,
+      "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": [
+      "@typescript-eslint"
+  ],
   "rules": {
     "@typescript-eslint/naming-convention": "warn",
     "@typescript-eslint/semi": "warn",
@@ -21,3 +24,4 @@
     "import/no-unresolved": "off"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
 			{
 				"command": "gatsbyhub.installGatsby",
 				"title": "Install Gatsby"
+			},
+			{
+				"command": "gatsbyhub.createSite",
+				"title": "Create New Site"
 			}
 		],
 		"viewsContainers": {
@@ -56,7 +60,7 @@
 		"viewsWelcome": [
 			{
 				"view": "commands",
-				"contents": "[Install Gatsby](command:gatsbyhub.installGatsby)\n"
+				"contents": "[Install Gatsby](command:gatsbyhub.installGatsby)\n[Create New Site](command:gatsbyhub.createSite)\n"
 			}
 		]
 	},

--- a/src/commands/gatsbycli.ts
+++ b/src/commands/gatsbycli.ts
@@ -4,7 +4,9 @@ import * as vscode from 'vscode';
 import Utilities from '../utils/Utilities';
 
 export default class GatsbyCli {
-  // no need to instantiate to use this method in extenstion.ts
+  // installs gatsby-cli for the user when install gatsby button is clicked
+
+  //  static keyword: eliminates the need to instantiate to use this method in extenstion.ts
   static async installGatsby() {
     // if a gatsby terminal isn't open, create a new terminal. Otherwise, use gatsbyhub terminal
     const activeTerminal = Utilities.getActiveTerminal();
@@ -19,6 +21,24 @@ export default class GatsbyCli {
       // if the password is wrong, show inputbox again
       
     // else, show terminal
+
+    activeTerminal.show();
+  }
+
+  /**  creates a new site when 'Create New Site' button is clicked
+   * currently uses default gatsby starter, but uses gatsby new url. see https://www.gatsbyjs.com/docs/gatsby-cli/
+   * NOTE: new site will be created wherever the root directory is currently located
+   * the user terminal should be at the directory user wishes to download the files.
+   */
+  static async createSite() {
+    const activeTerminal = Utilities.getActiveTerminal();
+
+    // problem: does not work when creating a new folder
+    const root = await vscode.commands.executeCommand('vscode.openFolder');
+    console.log(root);
+
+    const siteName = await vscode.window.showInputBox({ placeHolder: 'Input new site name' });
+    activeTerminal.sendText(`gatsby new ${siteName}`);
 
     activeTerminal.show();
   }

--- a/src/commands/gatsbycli.ts
+++ b/src/commands/gatsbycli.ts
@@ -12,6 +12,7 @@ export default class GatsbyCli {
     const activeTerminal = Utilities.getActiveTerminal();
 
     activeTerminal.sendText('sudo npm install -g gatsby-cli');
+    // Creates a password inputbox when install gatsby button is clicked
     // NOTE: comeback to this
     // if admin password is required:
       // Creates an inputbox for password when install gatsby button is clicked

--- a/src/commands/gatsbycli.ts
+++ b/src/commands/gatsbycli.ts
@@ -5,11 +5,21 @@ import Utilities from '../utils/Utilities';
 
 export default class GatsbyCli {
   // no need to instantiate to use this method in extenstion.ts
-  static installGatsby() {
+  static async installGatsby() {
     // if a gatsby terminal isn't open, create a new terminal. Otherwise, use gatsbyhub terminal
     const activeTerminal = Utilities.getActiveTerminal();
 
     activeTerminal.sendText('sudo npm install -g gatsby-cli');
+    // NOTE: comeback to this
+    // if admin password is required:
+      // Creates an inputbox for password when install gatsby button is clicked
+      const inputPassword = await vscode.window.showInputBox({ password: true, placeHolder: 'Input administrator password' });
+      activeTerminal.sendText(inputPassword);
+
+      // if the password is wrong, show inputbox again
+      
+    // else, show terminal
+
     activeTerminal.show();
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,14 @@ import GatsbyCli from './commands/gatsbycli';
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
   vscode.commands.registerCommand(
+    // package.json command
     'gatsbyhub.installGatsby',
     GatsbyCli.installGatsby,
+  );
+
+  vscode.commands.registerCommand(
+    'gatsbyhub.createSite',
+    GatsbyCli.createSite,
   );
 }
 


### PR DESCRIPTION
## Types of changes
- [ ] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [x] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## Purpose
- Implement password input box that will show up when "Install Gatsby" button is clicked. 
- Partially implement createSite button, which will open new site name input box.

## Approach
New site functionality will not work when user creates and selects a new folder to download files for the new website from Gatsby. User must only use pre-existing folder.