### PR TITLE
Adds ability for status bar item to toggle server on and off and adds message to create site method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable changes to the "gatsbyhub" extension will be documented in this file
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Initial Release]
+
 ## [Unreleased]
 
-- Initial release
+## [0.1.0] - 2020-10-02
+
+- Added 'Create New Site' button
+- Added 'Develop Server' button
+- Added 'Develop' status bar item
+- Added 'Build Site' button
+- Updated 'Develop Server' functionality so that the button and status bar toggle between developing server and disposing server
+- Updated 'Create New Site' functionality so that message pops up with option to open new folder
 
 ## [0.0.2] - 2020-09-29
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gatsbyhub",
   "displayName": "GatsbyHub",
   "description": "A one stop shop for everything Gatsby",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "engines": {
     "vscode": "^1.49.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
         "title": "Develop Server"
       },
       {
+        "command": "gatsbyhub.disposeServer",
+        "title": "Dispose Server"
+      },
+      {
         "command": "gatsbyhub.openPluginDocs",
         "title": "Open Plugin Docs",
         "icon": "src/logo/download.svg"

--- a/src/commands/gatsbycli.ts
+++ b/src/commands/gatsbycli.ts
@@ -1,7 +1,7 @@
 // Extract commands and modularize them
 
 // import * as vscode from 'vscode';
-import { window, commands } from 'vscode';
+import { window, commands, StatusBarItem } from 'vscode';
 import StatusBar from '../utils/statusBarItem';
 import Utilities from '../utils/Utilities';
 
@@ -10,7 +10,16 @@ import Utilities from '../utils/Utilities';
 // }
 
 export default class GatsbyCli {
-  private serverStatus: boolean = false;
+  private serverStatus: boolean;
+  initStatusBar: void;
+
+  constructor() {
+    this.serverStatus = false;
+    this.initStatusBar = StatusBar.init();
+    this.toggleStatusBar = this.toggleStatusBar.bind(this);
+    this.developServer = this.developServer.bind(this);
+    this.disposeServer = this.disposeServer.bind(this);
+  }
 
   // installs gatsby-cli for the user when install gatsby button is clicked
   //  static keyword: eliminates the need to instantiate to use this method in extenstion.ts
@@ -49,26 +58,30 @@ export default class GatsbyCli {
     // console.log(root);
 
     const siteName = await window.showInputBox({
-      placeHolder: 'Input new site name',
+      placeHolder: 'Enter new site name',
     });
     activeTerminal.sendText(`gatsby new ${siteName}`);
 
     activeTerminal.show();
   }
 
-  static async developServer() {
+  public developServer() {
     const activeTerminal = Utilities.getActiveTerminal();
     activeTerminal.show();
-    console.log('Status Bar Command Worked!!');
-    // vscode.commands.executeCommand('createStatusBarItem');
     /** write in active terminal gatsby develop
-    options to set host, set port, to open site, and to use https - research how to create little
-    icons gatsby develop only works in the site directory, allow user to open folder for
-    their site directory
-    two seperate methods toggle between start and stop server
-    need a global variable to store whether or not server is running */
+     options to set host, set port, to open site, and to use https - research how to create little
+     icons gatsby develop only works in the site directory, allow user to open folder for
+     their site directory */
     activeTerminal.sendText('gatsby develop --open');
     activeTerminal.show();
+    this.toggleStatusBar();
+    window.showInformationMessage('Server Running on Port:8000');
+  }
+
+  public disposeServer() {
+    const activeTerminal = Utilities.getActiveTerminal();
+    activeTerminal.dispose();
+    this.toggleStatusBar();
   }
 
   static async build() {
@@ -78,13 +91,19 @@ export default class GatsbyCli {
     console.log('Build Site works!');
   }
 
-  private toggleStatusBarItem() {
-    // if (!this.serverStatus) {
-    //   StatusBar.offline();
-    // } else {
-    //   StatusBar.online();
-    // }
+  private toggleStatusBar(): void {
+    if (!this.serverStatus) {
+      console.log('Dispose Gatsby Server!');
+      StatusBar.offline(8000);
+    } else {
+      console.log('Develop Gatsby Server!');
+      StatusBar.online();
+    }
     this.serverStatus = !this.serverStatus;
+  }
+
+  public dispose() {
+    StatusBar.dispose();
   }
 
   static installPlugin() {

--- a/src/commands/gatsbycli.ts
+++ b/src/commands/gatsbycli.ts
@@ -1,6 +1,8 @@
 // Extract commands and modularize them
 
-import * as vscode from 'vscode';
+// import * as vscode from 'vscode';
+import { window, commands } from 'vscode';
+import StatusBar from '../utils/statusBarItem';
 import Utilities from '../utils/Utilities';
 
 // interface GatsbyCliInterface {
@@ -8,13 +10,9 @@ import Utilities from '../utils/Utilities';
 // }
 
 export default class GatsbyCli {
-  static status: boolean = false;
+  private serverStatus: boolean = false;
 
-  // constructor() {
-  //   this.status = false;
-  // }
   // installs gatsby-cli for the user when install gatsby button is clicked
-
   //  static keyword: eliminates the need to instantiate to use this method in extenstion.ts
   static async installGatsby() {
     // if a gatsby terminal isn't open, create a new terminal. Otherwise, use gatsbyhub terminal
@@ -25,7 +23,7 @@ export default class GatsbyCli {
     // NOTE: comeback to this
     // if admin password is required:
     // Creates an inputbox for password when install gatsby button is clicked
-    const inputPassword = await vscode.window.showInputBox({
+    const inputPassword = await window.showInputBox({
       password: true,
       placeHolder: 'Input administrator password',
     });
@@ -47,10 +45,10 @@ export default class GatsbyCli {
     const activeTerminal = Utilities.getActiveTerminal();
 
     // problem: does not work when creating a new folder
-    const root = await vscode.commands.executeCommand('vscode.openFolder');
+    const root = await commands.executeCommand('vscode.openFolder');
     // console.log(root);
 
-    const siteName = await vscode.window.showInputBox({
+    const siteName = await window.showInputBox({
       placeHolder: 'Input new site name',
     });
     activeTerminal.sendText(`gatsby new ${siteName}`);
@@ -73,6 +71,18 @@ export default class GatsbyCli {
   }
 
   static async build() {
+    const activeTerminal = Utilities.getActiveTerminal();
+    activeTerminal.sendText('gatsby build');
+    activeTerminal.show();
     console.log('Build Site works!');
+  }
+
+  private ToggleStatusBarItem() {
+    // if (!this.serverStatus) {
+    //   StatusBar.offline();
+    // } else {
+    //   StatusBar.online();
+    // }
+    this.serverStatus = !this.serverStatus;
   }
 }

--- a/src/commands/gatsbycli.ts
+++ b/src/commands/gatsbycli.ts
@@ -75,13 +75,14 @@ export default class GatsbyCli {
     activeTerminal.sendText('gatsby develop --open');
     activeTerminal.show();
     this.toggleStatusBar();
-    window.showInformationMessage('Server Running on Port:8000');
+    window.showInformationMessage('Gatsby Server Running on port:8000');
   }
 
   public disposeServer() {
     const activeTerminal = Utilities.getActiveTerminal();
     activeTerminal.dispose();
     this.toggleStatusBar();
+    window.showInformationMessage('Disposing Gatsby Server on port:8000');
   }
 
   static async build() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ export function activate(context: ExtensionContext) {
   subscriptions.push(
     registerCommand('gatsbyhub.disposeServer', gatsbyCli.disposeServer),
   );
+  subscriptions.push(registerCommand('gatsbyhub.build', GatsbyCli.build));
   subscriptions.push(
     registerCommand('gatsbyhub.openPluginDocs', GatsbyCli.installPlugin),
   );
@@ -41,7 +42,6 @@ export function activate(context: ExtensionContext) {
       treeDataProvider: new PluginProvider(),
     }),
   );
-  subscriptions.push(registerCommand('gatsbyhub.build', GatsbyCli.build));
   subscriptions.push(gatsbyCli);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,9 +36,11 @@ export function activate(context: ExtensionContext) {
   subscriptions.push(
     registerCommand('gatsbyhub.openPluginDocs', GatsbyCli.installPlugin),
   );
-  createTreeView('plugins', {
-    treeDataProvider: new PluginProvider(),
-  });
+  subscriptions.push(
+    createTreeView('plugins', {
+      treeDataProvider: new PluginProvider(),
+    }),
+  );
   subscriptions.push(registerCommand('gatsbyhub.build', GatsbyCli.build));
   subscriptions.push(gatsbyCli);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { ExtensionContext, commands, window } from 'vscode';
 import GatsbyCli from './commands/gatsbycli';
 import StatusBar from './utils/statusBarItem';
 import PluginProvider from './models/PluginProvider';
@@ -10,23 +11,36 @@ import PluginProvider from './models/PluginProvider';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
-export function activate() {
-  const { createTreeView } = vscode.window;
-  const { registerCommand } = vscode.commands;
-  registerCommand(
-    // package.json command
-    'gatsbyhub.installGatsby',
-    GatsbyCli.installGatsby
+export function activate(context: ExtensionContext) {
+  const { createTreeView } = window;
+  const { registerCommand } = commands;
+  const { subscriptions } = context;
+  const gatsbyCli = new GatsbyCli();
+
+  subscriptions.push(
+    registerCommand(
+      // package.json command
+      'gatsbyhub.installGatsby',
+      GatsbyCli.installGatsby,
+    ),
   );
-  registerCommand('gatsbyhub.createSite', GatsbyCli.createSite);
-  registerCommand('gatsbyhub.developServer', GatsbyCli.developServer);
-  registerCommand('gatsbyhub.openPluginDocs', GatsbyCli.installPlugin);
+  subscriptions.push(
+    registerCommand('gatsbyhub.createSite', GatsbyCli.createSite),
+  );
+  subscriptions.push(
+    registerCommand('gatsbyhub.developServer', gatsbyCli.developServer),
+  );
+  subscriptions.push(
+    registerCommand('gatsbyhub.disposeServer', gatsbyCli.disposeServer),
+  );
+  subscriptions.push(
+    registerCommand('gatsbyhub.openPluginDocs', GatsbyCli.installPlugin),
+  );
   createTreeView('plugins', {
     treeDataProvider: new PluginProvider(),
   });
-  StatusBar.createStatusBarItem();
-  //   context.subscriptions.push(sb);
-  vscode.commands.registerCommand('gatsbyhub.build', GatsbyCli.build);
+  subscriptions.push(registerCommand('gatsbyhub.build', GatsbyCli.build));
+  subscriptions.push(gatsbyCli);
 }
 
 // this method is called when your extension is deactivated

--- a/src/utils/statusBarItem.ts
+++ b/src/utils/statusBarItem.ts
@@ -4,19 +4,37 @@ import { window, StatusBarItem } from 'vscode';
 export default class StatusBar {
   private static statusBarItem: StatusBarItem;
 
-  static createStatusBarItem() {
+  private static get Item() {
     if (!StatusBar.statusBarItem) {
       StatusBar.statusBarItem = window.createStatusBarItem(
         vscode.StatusBarAlignment.Right,
         100,
       );
     }
-    // $(pulse) $(broadcast) $(x) $(circle-slash)
-    StatusBar.statusBarItem.text =
-      '$(broadcast)$(cloud-upload)$(rss)$(radio-tower) GatsbyHub';
+    // $(pulse) $(broadcast)$(cloud-upload)$(rss)$(radio-tower) $(circle-slash)
+    // StatusBar.statusBarItem.text = '$(radio-tower) GatsbyHub';
     StatusBar.statusBarItem.show();
+    return StatusBar.statusBarItem;
     // status refers to whether server is running
+  }
 
-    StatusBar.statusBarItem.command = 'gatsbyhub.developServer';
+  static init() {
+    StatusBar.online();
+  }
+
+  public static online() {
+    StatusBar.Item.text = '$(radio-tower) GatsbyHub';
+    StatusBar.Item.tooltip = 'Click to develop Gatsby server';
+    StatusBar.Item.command = 'gatsbyhub.developServer';
+  }
+
+  public static offline(port: Number = 8000) {
+    StatusBar.Item.text = `$(circle-slash) Port: ${port}`;
+    StatusBar.Item.tooltip = 'Click to close Gatsby server';
+    StatusBar.statusBarItem.command = 'gatsbyhub.disposeServer';
+  }
+
+  public static dispose() {
+    StatusBar.Item.dispose();
   }
 }

--- a/src/utils/statusBarItem.ts
+++ b/src/utils/statusBarItem.ts
@@ -2,8 +2,10 @@ import * as vscode from 'vscode';
 import { window, StatusBarItem } from 'vscode';
 
 export default class StatusBar {
+  // defines the type to be a vscode.StatusBarItem
   private static statusBarItem: StatusBarItem;
 
+  // returns a StatusBarItem when called on by other StatusBar methods
   private static get Item() {
     if (!StatusBar.statusBarItem) {
       StatusBar.statusBarItem = window.createStatusBarItem(
@@ -12,16 +14,17 @@ export default class StatusBar {
       );
     }
     // $(pulse) $(broadcast)$(cloud-upload)$(rss)$(radio-tower) $(circle-slash)
-    // StatusBar.statusBarItem.text = '$(radio-tower) GatsbyHub';
     StatusBar.statusBarItem.show();
     return StatusBar.statusBarItem;
-    // status refers to whether server is running
   }
 
+  // initializes the statusBar by calling StatusBar.online method
+  // this is currently redundant, but it allows for loading sequence if we want
   static init() {
     StatusBar.online();
   }
 
+  // GatsbyCli toggles statusBar between online() and offline() methods
   public static online() {
     StatusBar.Item.text = '$(radio-tower) GatsbyHub';
     StatusBar.Item.tooltip = 'Click to develop Gatsby server';

--- a/src/utils/statusBarItem.ts
+++ b/src/utils/statusBarItem.ts
@@ -1,17 +1,22 @@
 import * as vscode from 'vscode';
+import { window, StatusBarItem } from 'vscode';
 
 export default class StatusBar {
+  private static statusBarItem: StatusBarItem;
+
   static createStatusBarItem() {
-    const myStatusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem(
-      vscode.StatusBarAlignment.Right,
-      100,
-    );
-    myStatusBarItem.text = 'GatsbyHub';
-    myStatusBarItem.show();
+    if (!StatusBar.statusBarItem) {
+      StatusBar.statusBarItem = window.createStatusBarItem(
+        vscode.StatusBarAlignment.Right,
+        100,
+      );
+    }
+    // $(pulse) $(broadcast) $(x) $(circle-slash)
+    StatusBar.statusBarItem.text =
+      '$(broadcast)$(cloud-upload)$(rss)$(radio-tower) GatsbyHub';
+    StatusBar.statusBarItem.show();
     // status refers to whether server is running
 
-    myStatusBarItem.command = 'gatsbyhub.developServer';
-
-    // context.subscriptions.push(myStatusBarItem);
+    StatusBar.statusBarItem.command = 'gatsbyhub.developServer';
   }
 }


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## Purpose
StatusBarItem and 'Develop Server' button had the ability to turn the server on, but they did not toggle their functionality and there was no way to turn the server off. Additionally, the 'Create New Site' button would ask you to open a folder to put your project in and the method would end if you opened a new folder.

## Approach
Implemented a way to toggle the StatusBarItem and 'Develop Server' button by modularizing their functionality and creating a new instance of the GatsbyCli class. For the 'Create New Site' button, a new pop up message was created which alerts the user that the new site will be created in the current directory unless they open a new folder by pressing the 'Open Folder' button on the message. This serves as a work around so that the user has the option to open a new folder, but it does not force them to do so.

## Learning
[VSCode Live Server](https://github.com/ritwickdey/vscode-live-server)
The VSCode Live Server repository on GitHub has been a wealth of knowledge for how to modularize our own codebase and how to solve issues that have already been solved.
