### PR TITLE
Adds ability for status bar item to toggle server on and off and adds message to create site method

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,26 +1,23 @@
 {
-    "root": true,
-    "env": {
-      "browser": true,
-      "es2021": true
-    },
-    "extends": [
-      "airbnb-base"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "ecmaVersion": 12,
-      "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-      "@typescript-eslint/naming-convention": "warn",
-      "@typescript-eslint/semi": "warn",
-      "curly": "warn",
-      "eqeqeq": "warn",
-      "no-throw-literal": "warn",
-      "semi": "off"
-    }
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["airbnb-base"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/naming-convention": "warn",
+    "@typescript-eslint/semi": "warn",
+    "curly": "warn",
+    "eqeqeq": "warn",
+    "no-throw-literal": "warn",
+    "semi": "off",
+    "import/no-unresolved": "off"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [0.1.0] - 2020-10-02
 
+### Add
+
 - Added 'Create New Site' button
 - Added 'Develop Server' button
 - Added 'Develop' status bar item

--- a/package.json
+++ b/package.json
@@ -1,90 +1,90 @@
 {
-	"name": "gatsbyhub",
-	"displayName": "GatsbyHub",
-	"description": "A one stop shop for everything Gatsby",
-	"version": "0.0.1",
-	"engines": {
-		"vscode": "^1.49.0"
-	},
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-		"onCommand:gatsbyhub.helloWorld",
-		"onView:commands",
-		"onView:plugins",
-		"onView:starters"
-	],
-	"main": "./out/extension.js",
-	"contributes": {
-		"commands": [
-			{
-				"command": "gatsbyhub.helloWorld",
-				"title": "Hello World"
-			},
-			{
-				"command": "gatsbyhub.installGatsby",
-				"title": "Install Gatsby"
-			},
-			{
-				"command": "gatsbyhub.createSite",
-				"title": "Create New Site"
-			}
-		],
-		"viewsContainers": {
-			"activitybar": [
-				{
-					"id": "gatsbyHub",
-					"title": "GatsbyHub",
-					"icon": "src/logo/GatsbyHub-black.svg"
-				}
-			]
-		},
-		"views": {
-			"gatsbyHub": [
-				{
-					"id": "commands",
-					"name": "Commands",
-					"visibility": "collapsed"
-				},
-				{
-					"id": "plugins",
-					"name": "Plugins"
-				},
-				{
-					"id": "starters",
-					"name": "Starters"
-				}
-			]
-		},
-		"viewsWelcome": [
-			{
-				"view": "commands",
-				"contents": "[Install Gatsby](command:gatsbyhub.installGatsby)\n[Create New Site](command:gatsbyhub.createSite)\n"
-			}
-		]
-	},
-	"scripts": {
-		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./",
-		"lint": "eslint src --ext ts",
-		"watch": "tsc -watch -p ./",
-		"pretest": "npm run compile && npm run lint",
-		"test": "node ./out/test/runTest.js"
-	},
-	"devDependencies": {
-		"@types/glob": "^7.1.3",
-		"@types/mocha": "^8.0.0",
-		"@types/node": "^14.0.27",
-		"@types/vscode": "^1.49.0",
-		"@typescript-eslint/eslint-plugin": "^4.3.0",
-		"@typescript-eslint/parser": "^4.3.0",
-		"eslint": "^7.10.0",
-		"eslint-config-airbnb-base": "^14.2.0",
-		"eslint-plugin-import": "^2.22.1",
-		"glob": "^7.1.6",
-		"mocha": "^8.1.3",
-		"typescript": "^4.0.2",
-		"vscode-test": "^1.4.0"
-	}
+  "name": "gatsbyhub",
+  "displayName": "GatsbyHub",
+  "description": "A one stop shop for everything Gatsby",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.49.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:gatsbyhub.helloWorld",
+    "onView:commands",
+    "onView:plugins",
+    "onView:starters"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "gatsbyhub.helloWorld",
+        "title": "Hello World"
+      },
+      {
+        "command": "gatsbyhub.installGatsby",
+        "title": "Install Gatsby"
+      },
+      {
+        "command": "gatsbyhub.createSite",
+        "title": "Create New Site"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "gatsbyHub",
+          "title": "GatsbyHub",
+          "icon": "src/logo/GatsbyHub-black.svg"
+        }
+      ]
+    },
+    "views": {
+      "gatsbyHub": [
+        {
+          "id": "commands",
+          "name": "Commands",
+          "visibility": "collapsed"
+        },
+        {
+          "id": "plugins",
+          "name": "Plugins"
+        },
+        {
+          "id": "starters",
+          "name": "Starters"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "commands",
+        "contents": "[Install Gatsby](command:gatsbyhub.installGatsby)\n[Create New Site](command:gatsbyhub.createSite)\n"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "lint": "eslint src --ext ts",
+    "watch": "tsc -watch -p ./",
+    "pretest": "npm run compile && npm run lint",
+    "test": "node ./out/test/runTest.js"
+  },
+  "devDependencies": {
+    "@types/glob": "^7.1.3",
+    "@types/mocha": "^8.0.0",
+    "@types/node": "^14.0.27",
+    "@types/vscode": "^1.49.0",
+    "@typescript-eslint/eslint-plugin": "^4.3.0",
+    "@typescript-eslint/parser": "^4.3.0",
+    "eslint": "^7.10.0",
+    "eslint-config-airbnb-base": "^14.2.0",
+    "eslint-plugin-import": "^2.22.1",
+    "glob": "^7.1.6",
+    "mocha": "^8.1.3",
+    "typescript": "^4.0.2",
+    "vscode-test": "^1.4.0"
+  }
 }

--- a/src/commands/gatsbycli.ts
+++ b/src/commands/gatsbycli.ts
@@ -3,15 +3,13 @@
 import * as vscode from 'vscode';
 import Utilities from '../utils/Utilities';
 
-
 export default class GatsbyCli {
-    // no need to instantiate to use this method in extenstion.ts
-    static installGatsby() {
-        // if a gatsby terminal isn't open, create a new terminal. Otherwise, use gatsbyhub terminal 
-        const activeTerminal = Utilities.getActiveTerminal();
+  // no need to instantiate to use this method in extenstion.ts
+  static installGatsby() {
+    // if a gatsby terminal isn't open, create a new terminal. Otherwise, use gatsbyhub terminal
+    const activeTerminal = Utilities.getActiveTerminal();
 
-        activeTerminal.sendText("sudo npm install -g gatsby-cli");
-        activeTerminal.show();
-    }
+    activeTerminal.sendText('sudo npm install -g gatsby-cli');
+    activeTerminal.show();
+  }
 }
-

--- a/src/commands/gatsbycli.ts
+++ b/src/commands/gatsbycli.ts
@@ -15,12 +15,15 @@ export default class GatsbyCli {
     // Creates a password inputbox when install gatsby button is clicked
     // NOTE: comeback to this
     // if admin password is required:
-      // Creates an inputbox for password when install gatsby button is clicked
-      const inputPassword = await vscode.window.showInputBox({ password: true, placeHolder: 'Input administrator password' });
-      activeTerminal.sendText(inputPassword);
+    // Creates an inputbox for password when install gatsby button is clicked
+    const inputPassword = await vscode.window.showInputBox({
+      password: true,
+      placeHolder: 'Input administrator password',
+    });
+    activeTerminal.sendText(inputPassword);
 
-      // if the password is wrong, show inputbox again
-      
+    // if the password is wrong, show inputbox again
+
     // else, show terminal
 
     activeTerminal.show();
@@ -38,7 +41,9 @@ export default class GatsbyCli {
     const root = await vscode.commands.executeCommand('vscode.openFolder');
     console.log(root);
 
-    const siteName = await vscode.window.showInputBox({ placeHolder: 'Input new site name' });
+    const siteName = await vscode.window.showInputBox({
+      placeHolder: 'Input new site name',
+    });
     activeTerminal.sendText(`gatsby new ${siteName}`);
 
     activeTerminal.show();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,10 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
     GatsbyCli.installGatsby,
   );
 
-  vscode.commands.registerCommand(
-    'gatsbyhub.createSite',
-    GatsbyCli.createSite,
-  );
+  vscode.commands.registerCommand('gatsbyhub.createSite', GatsbyCli.createSite);
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,10 @@ import GatsbyCli from './commands/gatsbycli';
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-	vscode.commands.registerCommand('gatsbyhub.installGatsby', GatsbyCli.installGatsby);
+  vscode.commands.registerCommand(
+    'gatsbyhub.installGatsby',
+    GatsbyCli.installGatsby,
+  );
 }
 
 // this method is called when your extension is deactivated

--- a/src/utils/Utilities.ts
+++ b/src/utils/Utilities.ts
@@ -1,26 +1,29 @@
 // Helper functions for gatsbycli.ts
 import * as vscode from 'vscode';
+
 interface Terminal {
-    sendText: any,
-    show: any,
+  sendText: any;
+  show: any;
+  name: string;
 }
 
 export default class Utilities {
+  static getActiveTerminal() {
+    const { terminals } = vscode.window;
+    const filtered = terminals.filter(
+      (obj: Terminal) => obj.name === 'gatsbyhub',
+    );
 
-    static getActiveTerminal() {
-        const { terminals } = vscode.window;
-        const filtered = terminals.filter(obj => obj.name === "gatsbyhub");
+    let terminal: Terminal;
 
-        let terminal: Terminal;
-
-        // if there is no gatsby terminal running, create one
-        if (filtered.length === 0) {
-            terminal = vscode.window.createTerminal("gatsbyhub");
-        } else { 
-            // if gatsby terminal already exists, return it
-             terminal = filtered[0];
-        }
-
-        return terminal;
+    // if there is no gatsby terminal running, create one
+    if (filtered.length === 0) {
+      terminal = vscode.window.createTerminal('gatsbyhub');
+    } else {
+      // if gatsby terminal already exists, return it
+      [terminal] = filtered;
     }
+
+    return terminal;
+  }
 }


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## Purpose
StatusBarItem and 'Develop Server' button had the ability to turn the server on, but they did not toggle their functionality and there was no way to turn the server off. Additionally, the 'Create New Site' button would ask you to open a folder to put your project in and the method would end if you opened a new folder.

## Approach
Implemented a way to toggle the StatusBarItem and 'Develop Server' button by modularizing their functionality and creating a new instance of the GatsbyCli class. For the 'Create New Site' button, a new pop up message was created which alerts the user that the new site will be created in the current directory unless they open a new folder by pressing the 'Open Folder' button on the message. This serves as a work around so that the user has the option to open a new folder, but it does not force them to do so.

## Learning
[VSCode Live Server](https://github.com/ritwickdey/vscode-live-server)
The VSCode Live Server repository on GitHub has been a wealth of knowledge for how to modularize our own codebase and how to solve issues that have already been solved.