### PR TITLE
(update) password requriement for install Gatsby moved inside of cond…

### DIFF
--- a/src/models/GatsbyCli.ts
+++ b/src/models/GatsbyCli.ts
@@ -33,19 +33,20 @@ export default class GatsbyCli {
     } else {
       // then it is linux or unnix based environment
       activeTerminal.sendText('sudo npm install -g gatsby-cli');
+      // Mac and Linux requrie password to install
+      const inputPassword = await window.showInputBox({
+        password: true,
+        placeHolder: 'Input administrator password',
+      });
+      if (inputPassword !== undefined) activeTerminal.sendText(inputPassword);
+      // if the password is wrong, show inputbox again
+      // else, show terminal
     }
-    // !! check if admin password is required before showing password box
-
-    // Creates a password inputbox when install gatsby button is clicked
-    const inputPassword = await window.showInputBox({
-      password: true,
-      placeHolder: 'Input administrator password',
-    });
-    if (inputPassword !== undefined) activeTerminal.sendText(inputPassword);
-    // if the password is wrong, show inputbox again
-    // else, show terminal
     activeTerminal.show(true);
   }
+  // !! check if admin password is required before showing password box
+
+  // Creates a password inputbox when install gatsby button is clicked
 
   /**  creates a new site when 'Create New Site' button is clicked
    * currently uses default gatsby starter, but uses gatsby new url. see https://www.gatsbyjs.com/docs/gatsby-cli/


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Windows users are now able to utilize Install Gatsby button and they are not prompted to put in their password.  Unix and Linux based users are still able to install and are prompted to put in their password
## Approach
Utilized the process.env object where windows users have a USERNAME property on the object and Unix/Linux has a USER property 