### PR TITLE
Add conditional checks for CLI commands

### DIFF
--- a/src/models/GatsbyCli.ts
+++ b/src/models/GatsbyCli.ts
@@ -133,8 +133,6 @@ export default class GatsbyCli {
   /* ------ Starts development server and opens project in a new browser ------ */
 
   public async developServer(): Promise<null> {
-    // finds path to file in text editor and drops the file name from the path
-    const rootPath = await Utilities.getRootPath();
     const gatsbyIsInitiated:
       | boolean
       | null = await Utilities.checkIfGatsbySiteInitiated();
@@ -167,10 +165,6 @@ export default class GatsbyCli {
 
     const activeTerminal = Utilities.getActiveServerTerminal();
 
-    // only cd into rootpath if it exists, otherwise just run command on current workspace
-    if (rootPath) {
-      activeTerminal.sendText(`cd && cd ${rootPath}`);
-    }
     activeTerminal.sendText('gatsby develop --open');
     // change status bar to working message while server finishes developing
     StatusBar.working('Starting server');
@@ -217,15 +211,15 @@ export default class GatsbyCli {
       return;
     }
     // finds path to file in text editor and drops the file name from the path
-    const rootPath = Utilities.getRootPath();
+    // const rootPath = Utilities.getRootPath();
 
     const activeTerminal = Utilities.getActiveTerminal();
     activeTerminal.show(true);
 
-    // only cd into rootpath if it exists, otherwise just run command on current workspace
-    if (rootPath) {
-      activeTerminal.sendText(`cd && cd ${rootPath}`);
-    }
+    // // only cd into rootpath if it exists, otherwise just run command on current workspace
+    // if (rootPath) {
+    //   activeTerminal.sendText(`cd && cd ${rootPath}`);
+    // }
     activeTerminal.sendText('gatsby build');
   }
 
@@ -265,21 +259,21 @@ export default class GatsbyCli {
       }
       return;
     }
-    const rootPath = await Utilities.getRootPath();
+    // const rootPath = await Utilities.getRootPath();
     const { name, links } = plugin.command.arguments[0];
     if (plugin) {
       const installCmnd =
         (await PluginData.getNpmInstall(links.repository, links.homepage)) ||
         `npm install ${name}`;
 
-      if (rootPath) {
-        activeTerminal.sendText(`cd && cd ${rootPath}`);
-        activeTerminal.sendText(installCmnd);
-        activeTerminal.show(true);
-      } else {
-        activeTerminal.sendText(installCmnd);
-        activeTerminal.show(true);
-      }
+      // if (rootPath) {
+      //   activeTerminal.sendText(`cd && cd ${rootPath}`);
+      //   activeTerminal.sendText(installCmnd);
+      //   activeTerminal.show(true);
+      // } else {
+      // }
+      activeTerminal.sendText(installCmnd);
+      activeTerminal.show(true);
       // check for if "plugin" is a theme or actual plugin
       if (name.startsWith('gatsby-theme')) {
         window.showInformationMessage(

--- a/src/utils/Utilities.ts
+++ b/src/utils/Utilities.ts
@@ -101,6 +101,10 @@ export default class Utilities {
   }
 
   static async getRootPath(): Promise<string | undefined> {
+    // replaces spaces with backslash
+    // .replace(/\s/g, '\\ ')
+    // drops fileName and common folders that aren't part of the root path
+    // .replace(/\/(src\/)?(pages\/)?(components\/)?[a-zA-Z\-\d]+\.(ts)?(js)?x?/, '')
     const uri = await this.getWorkspaceUri();
 
     return uri?.path;

--- a/src/utils/Utilities.ts
+++ b/src/utils/Utilities.ts
@@ -9,7 +9,7 @@ import {
 } from 'vscode';
 
 export default class Utilities {
-  static getActiveTerminal() {
+  static getActiveTerminal(): Terminal {
     const { terminals, createTerminal } = window;
     const filteredTerminals = terminals.filter(
       (obj: Terminal) => obj.name === 'GatsbyHub'
@@ -28,7 +28,7 @@ export default class Utilities {
     return terminal;
   }
 
-  static getActiveServerTerminal() {
+  static getActiveServerTerminal(): Terminal {
     const { terminals, createTerminal } = window;
     const filteredTerminals = terminals.filter(
       (obj: Terminal) => obj.name === 'Gatsby Server'
@@ -45,63 +45,68 @@ export default class Utilities {
     return terminal;
   }
 
-  static async checkIfWorkspaceEmpty(): Promise<boolean> {
+  static async getWorkspaceUri(): Promise<Uri | undefined> {
     const currWorkspace: readonly WorkspaceFolder[] | undefined =
       workspace.workspaceFolders;
 
-    if (currWorkspace === undefined) return false;
-
-    const uri = Uri.file(currWorkspace[0].uri.path);
-
-    const data = await workspace.fs.readDirectory(uri);
-
-    return data.length < 1;
-  }
-
-  static async checkIfGatsbySiteInitiated(root: string): Promise<boolean> {
-    const uri = Uri.file(root);
-
-    const data = await workspace.fs.readDirectory(uri);
-
-    // if workspace is empty, that means a gatsby site has not been initiated
-    if (data.length < 1) return false;
-
-    let initiated: boolean = false;
-    // if there are files/folders
-    data.forEach((file) => {
-      // if one of these files is gatsby-config set initiated to true
-      if (file[0] === 'gatsby-config.js') initiated = true;
-    });
-
-    return initiated;
-  }
-
-  static getRootPath(): string {
-    if (window.activeTextEditor) {
-      return (
-        // gets path to file in active text editor
-        window.activeTextEditor?.document.fileName
-          // replaces spaces with backslash
-          .replace(/\s/g, '\\ ')
-          // drops fileName and common folders that aren't part of the root path
-          .replace(
-            /\/(src\/)?(pages\/)?(components\/)?[a-zA-Z\-\d]+\.(ts)?(js)?x?/,
-            ''
-          )
+    if (currWorkspace === undefined) {
+      const input = await window.showErrorMessage(
+        'A workspace must be open. Choose a folder to work in.',
+        'Open Folder',
+        'Cancel'
       );
+      if (input === 'Open Folder') {
+        commands.executeCommand('vscode.openFolder');
+      }
+
+      return currWorkspace;
     }
 
-    const currWorkspace: readonly WorkspaceFolder[] | undefined =
-      workspace.workspaceFolders;
-
-    console.log('currSpace --> ', currWorkspace[0].name);
-    if (currWorkspace === undefined) return currWorkspace;
-
     const uri = Uri.file(currWorkspace[0].uri.path);
-    return uri.path;
+
+    return uri;
   }
 
-  static async openGraphiQL() {
+  static async checkIfWorkspaceEmpty(): Promise<boolean> {
+    const uri = await this.getWorkspaceUri();
+
+    if (uri) {
+      const data = await workspace.fs.readDirectory(uri);
+      return data.length < 1;
+    }
+
+    return true;
+  }
+
+  static async checkIfGatsbySiteInitiated(): Promise<boolean | null> {
+    const uri = await this.getWorkspaceUri();
+
+    if (uri) {
+      const data = await workspace.fs.readDirectory(uri);
+
+      // if workspace is empty, that means a gatsby site has not been initiated
+      if (data.length < 1) return false;
+
+      let initiated: boolean = false;
+      // if there are files/folders
+      data.forEach((file) => {
+        // if one of these files is gatsby-config set initiated to true
+        if (file[0] === 'gatsby-config.js') initiated = true;
+      });
+
+      return initiated;
+    }
+
+    return null;
+  }
+
+  static async getRootPath(): Promise<string | undefined> {
+    const uri = await this.getWorkspaceUri();
+
+    return uri?.path;
+  }
+
+  static openGraphiQL() {
     commands.executeCommand(
       'vscode.open',
       Uri.parse('http://localhost:8000/___graphql')


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Add method that gets workspace URI
Update conditional checks in createSite, buildSite, developServer, and installPlugin that checks it's workspace and executes accordingly
## Approach
<!--- How does your change address the problem? -->
Certain commands only run if the workspace doesn't have multiple projects (and vice versa)
Grab the workspace and read it's directory