### PR TITLE
(add) Interfaces file and changes 'any' types to reference interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Interact with Gatsby without ever having to use the command line interface. Gats
 - Develop Server - Start and stop a development server by either clicking the button or clicking the status bar item
 - Build Site - Build and package your site so it's ready to deploy on Gatsby's cloud
 
+<p align="center">
+  <br />
+  <img src="src/images/gh-readme-demo.gif" alt="GatsbyHub Preview" width="900rem" />
+  <br />
+</p>
+
 ## Gatsby Plugins
 
 Find and download Gatsby plugins without ever leaving VSCode. Gatsby is known for it's active community and many plugins. You can find Gatsby's official plugins and all the documentation needed to implement them into your project.

--- a/src/models/GatsbyCli.ts
+++ b/src/models/GatsbyCli.ts
@@ -4,6 +4,7 @@ import { window, commands, workspace } from 'vscode';
 import StatusBar from '../utils/statusBarItem';
 import Utilities from '../utils/Utilities';
 import PluginData from './NpmData';
+import { NpmTreeItem } from '../utils/Interfaces';
 
 // Defines the functionality of the Gatsby CLI Commands
 export default class GatsbyCli {
@@ -52,7 +53,7 @@ export default class GatsbyCli {
    * NOTE: new site will be created wherever the root directory is currently located
    * the user terminal should be at the directory user wishes to download the files.
    */
-  async createSite(starterObj?: any) {
+  async createSite(starterObj?: NpmTreeItem) {
     // get GatsbyHub terminal or create a new terminal if it doesn't exist
     const activeTerminal = Utilities.getActiveTerminal();
     // define string for button in information message
@@ -214,11 +215,11 @@ export default class GatsbyCli {
     StatusBar.dispose();
   }
 
-  async installPlugin(plugin?: any): Promise<void> {
+  async installPlugin(plugin?: NpmTreeItem): Promise<void> {
     const activeTerminal = Utilities.getActiveTerminal();
     const rootPath = Utilities.getRootPath();
-    const { name, links } = plugin.command.arguments[0];
     if (plugin) {
+      const { name, links } = plugin.command.arguments[0];
       const installCmnd =
         (await PluginData.getNpmInstall(links.repository, links.homepage)) ||
         `npm install ${name}`;

--- a/src/models/NpmData.ts
+++ b/src/models/NpmData.ts
@@ -2,21 +2,7 @@
 /* eslint-disable no-param-reassign */
 import got from 'got';
 import * as marked from 'marked';
-
-// defines object shape of each element in merged array
-interface NpmPkg {
-  package: { name: string };
-}
-
-// defines object shape of each plugin package in array
-interface PluginPkg {
-  name: string;
-  links: {
-    repository: string;
-    homepage: string;
-  };
-  readme: string;
-}
+import { PluginPkg, NpmPkg } from '../utils/Interfaces';
 
 export default class NpmData {
   pluginKeywords: string[];

--- a/src/models/PluginProvider.ts
+++ b/src/models/PluginProvider.ts
@@ -1,6 +1,7 @@
 import { TreeDataProvider } from 'vscode';
 import Plugin from './Plugin';
 import NpmData from './NpmData';
+import { PluginPkg } from '../utils/Interfaces';
 
 export default class PluginProvider implements TreeDataProvider<Plugin> {
   data: any;
@@ -12,8 +13,8 @@ export default class PluginProvider implements TreeDataProvider<Plugin> {
 
   async createPlugins() {
     const npmData = new NpmData();
-    return (await npmData.getNpmPackages('plugin')).map(
-      (obj: any) =>
+    return (await Promise.all(await npmData.getNpmPackages('plugin'))).map(
+      (obj: PluginPkg) =>
         new Plugin(obj.name, {
           command: 'gatsbyhub.createWebView',
           title: 'Show Plugin WebView',

--- a/src/models/StarterProvider.ts
+++ b/src/models/StarterProvider.ts
@@ -1,6 +1,7 @@
 import { TreeDataProvider } from 'vscode';
 import Starter from './Starter';
 import NpmData from './NpmData';
+import { PluginPkg } from '../utils/Interfaces';
 
 export default class StarterProvider
 implements TreeDataProvider<Starter> {
@@ -13,8 +14,8 @@ implements TreeDataProvider<Starter> {
 
   async createPlugins() {
     const npmData = new NpmData();
-    return (await npmData.getNpmPackages('starter')).map(
-      (obj: any) =>
+    return (await Promise.all(await npmData.getNpmPackages('starter'))).map(
+      (obj: PluginPkg) =>
         new Starter(obj.name, {
           command: 'gatsbyhub.createWebView',
           title: 'Show Starter WebView',

--- a/src/models/ThemeProvider.ts
+++ b/src/models/ThemeProvider.ts
@@ -1,6 +1,7 @@
 import { TreeDataProvider } from 'vscode';
 import Theme from './Theme';
 import NpmData from './NpmData';
+import { PluginPkg } from '../utils/Interfaces';
 
 export default class ThemeProvider implements TreeDataProvider<Theme> {
   data: any;
@@ -12,8 +13,8 @@ export default class ThemeProvider implements TreeDataProvider<Theme> {
 
   async createPlugins() {
     const npmData = new NpmData();
-    return (await npmData.getNpmPackages('theme')).map(
-      (obj: any) =>
+    return (await Promise.all(await npmData.getNpmPackages('theme'))).map(
+      (obj: PluginPkg) =>
         new Theme(obj.name, {
           command: 'gatsbyhub.createWebView',
           title: 'Show Theme WebView',

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -1,0 +1,39 @@
+// defines object shape of each plugin package in array served by NpmData.getNpmPackages
+export interface PluginPkg {
+    name: string;
+    links: {
+      repository: string;
+      homepage: string;
+    };
+    readme: string;
+  }
+
+// defines object shape of each element in merged array when first fetching npmPackages in NpmData
+export interface NpmPkg {
+    package: {
+      name: string;
+      links: {
+        repository: string;
+        homepage: string;
+      };
+      readme: string;
+    };
+  }
+
+// defines object shape of each of the TreeItems in Views: Plugins, Starters, Themes
+export interface NpmTreeItem {
+    command: {
+      arguments: [
+        {
+          name: string;
+          links: {
+            repository: string;
+            homepage: string;
+          };
+          readme: string;
+          version: string;
+          description: string;
+        }
+      ]
+    }
+  }

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -6,6 +6,8 @@ export interface PluginPkg {
       homepage: string;
     };
     readme: string;
+    version: string;
+    description: string;
   }
 
 // defines object shape of each element in merged array when first fetching npmPackages in NpmData

--- a/src/utils/Utilities.ts
+++ b/src/utils/Utilities.ts
@@ -76,7 +76,7 @@ export default class Utilities {
     return initiated;
   }
 
-  static getRootPath(): string {
+  static getRootPath(): string | undefined {
     if (window.activeTextEditor) {
       return (
         // gets path to file in active text editor
@@ -94,7 +94,7 @@ export default class Utilities {
     const currWorkspace: readonly WorkspaceFolder[] | undefined =
       workspace.workspaceFolders;
 
-    console.log('currSpace --> ', currWorkspace[0].name);
+    // console.log('currSpace --> ', currWorkspace[0].name);
     if (currWorkspace === undefined) return currWorkspace;
 
     const uri = Uri.file(currWorkspace[0].uri.path);

--- a/src/utils/WebViews.ts
+++ b/src/utils/WebViews.ts
@@ -29,6 +29,7 @@ export default class WebViews {
       ViewColumn.One
     );
 
+    const newFunc = (e: any) => console.log(e);
     // create a header for each npm package and display README underneath header
     // currently #install-btn does not work
     panel.webview.html = `
@@ -60,7 +61,7 @@ export default class WebViews {
     <div class="plugin-header">
       <div id="title-btn">
         <h1 id="title">${title}</h1>
-        <button id="install-btn">Install</button>
+        <a id="install-btn" href="command:gatsbyhub.installPlugin?%22default%22">Install</a>
       </div>
       <p>Version: ${version}</p>
       <p>${description}</p>

--- a/src/utils/WebViews.ts
+++ b/src/utils/WebViews.ts
@@ -1,19 +1,9 @@
 import { window, ViewColumn } from 'vscode';
 import PluginData from '../models/NpmData';
-
-interface NpmPkg {
-  name: string;
-  links: {
-    repository: string;
-    homepage: string;
-  };
-  readme: string;
-  version: string;
-  description: string;
-}
+import { PluginPkg } from '../utils/Interfaces';
 
 export default class WebViews {
-  static async openWebView(npmPackage: NpmPkg) {
+  static async openWebView(npmPackage: PluginPkg) {
     const { links, name, version, description } = npmPackage;
     const readMe = await PluginData.mdToHtml(links.repository, links.homepage);
 
@@ -29,7 +19,6 @@ export default class WebViews {
       ViewColumn.One
     );
 
-    const newFunc = (e: any) => console.log(e);
     // create a header for each npm package and display README underneath header
     // currently #install-btn does not work
     panel.webview.html = `
@@ -61,7 +50,7 @@ export default class WebViews {
     <div class="plugin-header">
       <div id="title-btn">
         <h1 id="title">${title}</h1>
-        <a id="install-btn" href="command:gatsbyhub.installPlugin?%22default%22">Install</a>
+        <a id="install-btn">Install</a>
       </div>
       <p>Version: ${version}</p>
       <p>${description}</p>

--- a/src/utils/WebViews.ts
+++ b/src/utils/WebViews.ts
@@ -1,9 +1,20 @@
 import { window, ViewColumn } from 'vscode';
 import PluginData from '../models/NpmData';
 
+interface NpmPkg {
+  name: string;
+  links: {
+    repository: string;
+    homepage: string;
+  };
+  readme: string;
+  version: string;
+  description: string;
+}
+
 export default class WebViews {
-  static async openWebView({ links, name, version, description }: any) {
-    // const { links, name, version, description } = npmPackage;
+  static async openWebView(npmPackage: NpmPkg) {
+    const { links, name, version, description } = npmPackage;
     const readMe = await PluginData.mdToHtml(links.repository, links.homepage);
 
     // turn npm package name from snake-case to standard capitalized title


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Previously, a lot of the methods took inputs or outputs that were of type any which defeats the purpose of using typescript.
## Approach
<!--- How does your change address the problem? -->
Created a file to hold the commonly used interfaces and then referenced them in every method that previously used 'any' type.