### PR TITLE
Fixes bug with serve command, sorts plugins by npm score, and adds error handling where get requests are made.

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,11 @@
 				"icon": "$(browser)"
 			},
 			{
+				"command": "gatsbyhub.openProdBrowser",
+				"title": "Open Browser",
+				"icon": "$(browser)"
+			},
+			{
 				"command": "buildFinished",
 				"title": "Site Built",
 				"icon": "$(check)"
@@ -200,6 +205,11 @@
 					"when": "view == commands && serverIsRunning == true"
 				},
 				{
+					"command": "gatsbyhub.disposeServer",
+					"group": "navigation",
+					"when": "view == commands && prodServerIsRunning == true"
+				},
+				{
 					"command": "gatsbyhub.openGraphiQL",
 					"group": "navigation",
 					"when": "view == commands && serverIsRunning == true"
@@ -208,6 +218,11 @@
 					"command": "gatsbyhub.openBrowser",
 					"group": "navigation",
 					"when": "view == commands && serverIsRunning == true"
+				},
+				{
+					"command": "gatsbyhub.openProdBrowser",
+					"group": "navigation",
+					"when": "view == commands && prodServerIsRunning == true"
 				},
 				{
 					"command": "gatsbyhub.openPluginDocs",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,9 @@ export function activate(context: ExtensionContext) {
 		registerCommand('gatsbyhub.openBrowser', Utilities.openBrowser)
 	);
 	subscriptions.push(
+		registerCommand('gatsbyhub.openProdBrowser', Utilities.openProdBrowser)
+	);
+	subscriptions.push(
 		createTreeView('commands', {
 			treeDataProvider: new CommandProvider(),
 		})

--- a/src/models/CommandProvider.ts
+++ b/src/models/CommandProvider.ts
@@ -7,48 +7,13 @@ export default class CLICommandProvider
 
 	constructor() {
 		this.data = [
-			new CLICommand(
-				'Install Gatsby',
-				undefined,
-				undefined,
-				'Install/Update Gatsby-cli'
-			),
-			new CLICommand(
-				'New Site',
-				undefined,
-				undefined,
-				'Create New Gatsby Site'
-			),
-			new CLICommand(
-				'Develop Server',
-				undefined,
-				undefined,
-				'Launch Development Server'
-			),
-			new CLICommand(
-				'Build Site',
-				undefined,
-				undefined,
-				'Package and Prepare Site for Deployment'
-			),
-			new CLICommand(
-				'Serve Site',
-				undefined,
-				undefined,
-				'Start Production Server'
-			),
-			new CLICommand(
-				'Info',
-				undefined,
-				undefined,
-				'Get Environment Information'
-			),
-			new CLICommand(
-				'Clean Cache',
-				undefined,
-				undefined,
-				'Clear Cache and Public Directories'
-			),
+			new CLICommand('Install Gatsby', 'Install/Update Gatsby-cli'),
+			new CLICommand('New Site', 'Create New Gatsby Site'),
+			new CLICommand('Develop Server', 'Launch Development Server'),
+			new CLICommand('Build Site', 'Package and Prepare Site for Deployment'),
+			new CLICommand('Serve Site', 'Start Production Server'),
+			new CLICommand('Info', 'Get Environment Information'),
+			new CLICommand('Clean Cache', 'Clear Cache and Public Directories'),
 		];
 	}
 

--- a/src/models/Commands.ts
+++ b/src/models/Commands.ts
@@ -3,9 +3,9 @@ import { TreeItem, Command, TreeItemCollapsibleState } from 'vscode';
 export default class CLICommand extends TreeItem {
 	constructor(
 		public label: string,
+		public tooltip?: string,
 		public command?: Command,
-		public children?: CLICommand[],
-		public tooltip?: string
+		public children?: CLICommand[]
 	) {
 		super(
 			label,

--- a/src/models/GatsbyCli.ts
+++ b/src/models/GatsbyCli.ts
@@ -359,7 +359,7 @@ export default class GatsbyCli {
 		activeTerminal.show(true);
 		activeTerminal.sendText(serve);
 		window.showInformationMessage(`Starting up port:${prodPort}`);
-		commands.executeCommand('setContext', 'serverIsRunning', true);
+		commands.executeCommand('setContext', 'prodServerIsRunning', true);
 		this.prodServerStatus = true;
 	}
 
@@ -382,6 +382,7 @@ export default class GatsbyCli {
 			this.prodServerStatus = false;
 		}
 		commands.executeCommand('setContext', 'serverIsRunning', false);
+		commands.executeCommand('setContext', 'prodServerIsRunning', false);
 	}
 
 	/* -------------------------------------------------------------------------- */

--- a/src/models/NpmData.ts
+++ b/src/models/NpmData.ts
@@ -38,7 +38,7 @@ export default class NpmData {
 			keywords.some((keyword) => name.startsWith(keyword));
 
 		// checks package names with weird prefixes
-		const hasGoodName = (pkg: PluginPkg) => {
+		const hasGoodName = (pkg: PluginPkg): boolean => {
 			const { name } = pkg;
 			const isScopedPackage = name.startsWith('@');
 			if (!isScopedPackage) {
@@ -49,12 +49,17 @@ export default class NpmData {
 		};
 
 		// checks that package has a readme
-		const hasReadMe = (pkg: PluginPkg) => {
+		const hasReadMe = async (pkg: PluginPkg): Promise<boolean> => {
 			if (pkg.links.homepage || pkg.readme) return true;
 			if (pkg.links.repository) {
-				return got(`${pkg.links.repository}/blob/master/README.md`)
-					.then((response: any) => response.statusCode === 200)
-					.catch(() => false);
+				try {
+					const response: any = await got(
+						`${pkg.links.repository}/blob/master/README.md`
+					);
+					return response.statusCode === 200;
+				} catch (error) {
+					throw new Error(error);
+				}
 			}
 			return false;
 		};
@@ -62,10 +67,14 @@ export default class NpmData {
 		// creates an array of npm objects based on keywords array
 		// npm objects contains number of packages and array of package objects
 		let npmPackages = keywords.map(async (keyword) => {
-			const url = `https://api.npms.io/v2/search?q=${keyword}&size=250`;
-			// +keywords:-gatsby-plugin+not:deprecated
-			const response = await got(url);
-			return JSON.parse(response.body);
+			try {
+				const url = `https://api.npms.io/v2/search?q=${keyword}&size=250`;
+				// +keywords:-gatsby-plugin+not:deprecated
+				const response = await got(url);
+				return JSON.parse(response.body);
+			} catch (error) {
+				throw new Error(error);
+			}
 		});
 
 		// merges the array of npm package objects together to a single array
@@ -74,9 +83,11 @@ export default class NpmData {
 			[]
 		);
 
-		// creates an object with unique package names and packages
-		// eliminates duplicate packages
-		// keys === plugin names, values === plugin packages
+		/**
+		 * creates an object with unique package names and packages
+		 * eliminates duplicate packages
+		 * keys === plugin names, values === plugin packages
+		 */
 		const uniquePackagesObj = (await Promise.all(npmPackages)).reduce(
 			(obj: any, elem: NpmPkg) => {
 				elem.package.score = elem.score.final;
@@ -102,8 +113,6 @@ export default class NpmData {
 		// check package is not a starter or theme
 		if (npmType === 'plugin') {
 			npmPackages = (await Promise.all(npmPackages)).filter(
-				// let theme: string = 'gatsby-theme';
-				// let starter: string = 'gatsby-starter';
 				(pkgs: PluginPkg) =>
 					!pkgs.name.startsWith('gatsby-theme' || 'gatsby-starter')
 			);
@@ -117,19 +126,23 @@ export default class NpmData {
 		// filters out packages without readme's
 		npmPackages = (await Promise.all(npmPackages)).filter(
 			async (pkg: PluginPkg) => {
-				const check = await hasReadMe(pkg);
-				return check;
+				try {
+					const check = await hasReadMe(pkg);
+					return check;
+				} catch (error) {
+					throw new Error(error);
+				}
 			}
 		);
 
 		/**
-		 * Sorts the plugins by npm 'final' score
-		 * highest score to lowest
+		 * Sorts the plugins by npm 'final' score.
+		 * Highest score to lowest.
 		 *
 		 * This score is calculated by the package's average:
 		 * Popularity score
-		 * Quality score
-		 * Maintenance score
+		 * Quality score &
+		 * Maintenance score.
 		 *
 		 */
 		npmPackages = (await Promise.all(npmPackages)).sort(
@@ -157,10 +170,9 @@ export default class NpmData {
 			}
 
 			const response = await got(goodUrl);
-
 			return response.body;
 		} catch (error) {
-			throw new Error(`Error in getReadMe: ${error}`);
+			throw new Error(error);
 		}
 	}
 
@@ -194,7 +206,7 @@ export default class NpmData {
 			const install = findNpm.slice(0, findNpm.indexOf('`'));
 			return install;
 		} catch (error) {
-			throw new Error(`Error in getNpmInstall: ${error}`);
+			throw new Error(error);
 		}
 	}
 }

--- a/src/models/NpmData.ts
+++ b/src/models/NpmData.ts
@@ -121,6 +121,17 @@ export default class NpmData {
 				return check;
 			}
 		);
+
+		/**
+		 * Sorts the plugins by npm 'final' score
+		 * highest score to lowest
+		 *
+		 * This score is calculated by the package's average:
+		 * Popularity score
+		 * Quality score
+		 * Maintenance score
+		 *
+		 */
 		npmPackages = (await Promise.all(npmPackages)).sort(
 			(a: PluginPkg, b: PluginPkg) => {
 				return a.score < b.score ? 1 : -1;

--- a/src/models/NpmData.ts
+++ b/src/models/NpmData.ts
@@ -79,6 +79,7 @@ export default class NpmData {
 		// keys === plugin names, values === plugin packages
 		const uniquePackagesObj = (await Promise.all(npmPackages)).reduce(
 			(obj: any, elem: NpmPkg) => {
+				elem.package.score = elem.score.final;
 				obj[elem.package.name] = obj[elem.package.name] || elem.package;
 				return obj;
 			},
@@ -118,6 +119,11 @@ export default class NpmData {
 			async (pkg: PluginPkg) => {
 				const check = await hasReadMe(pkg);
 				return check;
+			}
+		);
+		npmPackages = (await Promise.all(npmPackages)).sort(
+			(a: PluginPkg, b: PluginPkg) => {
+				return a.score < b.score ? 1 : -1;
 			}
 		);
 

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -8,6 +8,7 @@ export interface PluginPkg {
 	readme: string;
 	version: string;
 	description: string;
+	score: number;
 }
 
 // defines object shape of each element in merged array when first fetching npmPackages in NpmData
@@ -19,6 +20,10 @@ export interface NpmPkg {
 			homepage: string;
 		};
 		readme: string;
+		score: number;
+	};
+	score: {
+		final: number;
 	};
 }
 

--- a/src/utils/Utilities.ts
+++ b/src/utils/Utilities.ts
@@ -8,7 +8,8 @@ import {
 	Uri,
 } from 'vscode';
 
-import { getDevelopPortConfig } from './config/develop';
+import { getDevelopPortConfig, getDevelopHostConfig } from './config/develop';
+import { getServePortConfig, getServeHostConfig } from './config/serve';
 
 export default class Utilities {
 	static getActiveTerminal(): Terminal {
@@ -190,11 +191,16 @@ export default class Utilities {
 
 	static openBrowser() {
 		const port = getDevelopPortConfig();
+		const host = getDevelopHostConfig();
 
-		commands.executeCommand(
-			'vscode.open',
-			Uri.parse(`http://localhost:${port}`)
-		);
+		commands.executeCommand('vscode.open', Uri.parse(`http://${host}:${port}`));
+	}
+
+	static openProdBrowser() {
+		const port = getServePortConfig();
+		const host = getServeHostConfig();
+
+		commands.executeCommand('vscode.open', Uri.parse(`http://${host}:${port}`));
 	}
 
 	static getPortConfig(): number {

--- a/src/utils/config/develop.ts
+++ b/src/utils/config/develop.ts
@@ -3,10 +3,13 @@ import { workspace } from 'vscode';
 export const getDevelopPortConfig = (): number =>
 	workspace.getConfiguration('gatsbyhub').commands.develop.port;
 
+export const getDevelopHostConfig = (): number | string =>
+	workspace.getConfiguration('gatsbyhub').commands.serve.changeHost;
+
 export const getDevelopCmnd = () => {
 	const config = workspace.getConfiguration('gatsbyhub').commands.develop;
 	const { port } = config;
-	const host: number | string = config.changeHost;
+	const host = getDevelopHostConfig();
 	const openEnabled: boolean = config.openBrowser;
 	const httpsEnabled: boolean = config.useHttps;
 	const open = '-o';

--- a/src/utils/config/serve.ts
+++ b/src/utils/config/serve.ts
@@ -4,10 +4,13 @@ import { workspace } from 'vscode';
 export const getServePortConfig = (): number =>
 	workspace.getConfiguration('gatsbyhub').commands.serve.port;
 
+export const getServeHostConfig = (): number | string =>
+	workspace.getConfiguration('gatsbyhub').commands.serve.changeHost;
+
 export const getServeCmnd = () => {
 	const config = workspace.getConfiguration('gatsbyhub').commands.serve;
 	const { port } = config;
-	const host: number | string = config.changeHost;
+	const host = getServeHostConfig();
 	const openEnabled = config.openBrowser;
 	const httpsEnabled = config.useHttps;
 	const open = '-o';


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->

- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to **not** work as expected)

## Purpose

<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
To sort plugins, starters, and themes by their npm score
Fix bug with serve command where openBrowser was opening dev server url, and graphiql button was appearing
Adds trycatch blocks where get requests are made

