### PR TITLE
Fixes server error with fetching Plugin Data

### DIFF
--- a/src/models/NpmData.ts
+++ b/src/models/NpmData.ts
@@ -68,7 +68,7 @@ export default class NpmData {
 		// npm objects contains number of packages and array of package objects
 		let npmPackages = keywords.map(async (keyword) => {
 			try {
-				const url = `https://api.npms.io/v2/search?q=${keyword}&size=250`;
+				const url = `http://registry.npmjs.org/-/v1/search?text=${keyword}&size=250`;
 				// +keywords:-gatsby-plugin+not:deprecated
 				const response = await got(url);
 				return JSON.parse(response.body);
@@ -79,7 +79,7 @@ export default class NpmData {
 
 		// merges the array of npm package objects together to a single array
 		npmPackages = (await Promise.all(npmPackages)).reduce(
-			(arr, obj) => arr.concat(obj.results),
+			(arr, obj) => arr.concat(obj.objects),
 			[]
 		);
 

--- a/src/models/NpmData.ts
+++ b/src/models/NpmData.ts
@@ -68,7 +68,7 @@ export default class NpmData {
 		// npm objects contains number of packages and array of package objects
 		let npmPackages = keywords.map(async (keyword) => {
 			try {
-				const url = `http://registry.npmjs.org/-/v1/search?text=${keyword}&size=250`;
+				const url = `https://registry.npmjs.org/-/v1/search?text=${keyword}&size=250`;
 				// +keywords:-gatsby-plugin+not:deprecated
 				const response = await got(url);
 				return JSON.parse(response.body);


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->

- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to **not** work as expected)

## Purpose

Server was no longer working to fetch plugin packages. We updated the npms url to npmjs which fixed the issue.
